### PR TITLE
Rt sk add purchased checkbox

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  onSnapshot,
+  Timestamp,
+  doc,
+  updateDoc,
+} from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { getUser } from '../storage-utils/storage-utils';
 import Nav from './Nav';
@@ -7,6 +13,26 @@ import Nav from './Nav';
 export default function List() {
   const [docs, setDocs] = useState([]);
   const [userToken] = useState(getUser());
+
+  const handleCheckBox = (e, item) => {
+    e.preventDefault();
+    let now = Timestamp.now().seconds;
+    // console.log("NOW: ", now)
+    // let dayFromNow = now + 86400
+    // console.log("day later: ", dayFromNow);
+    const docItem = doc(db, userToken, item.id);
+    console.log('ITEM: ', docItem);
+
+    updateDoc(docItem, {
+      lastPurchaseDate: now,
+    });
+  };
+
+  const check24Hrs = (item) => {
+    //  have it check the last purchase date for the item
+    // take line 15 => run that difference.. eg; now - items purchase date?
+    console.log('check 24 item last purchase');
+  };
 
   useEffect(() => {
     const unsubscribe = onSnapshot(collection(db, userToken), (snapshot) => {
@@ -22,10 +48,22 @@ export default function List() {
   return (
     <>
       <h1>Shopping List</h1>
+
       <div>
-        {docs.map((item, index) => {
-          return <p key={index}>{item.data().item}</p>;
-        })}
+        <ul>
+          {docs.map((item, index) => {
+            return (
+              <li key={index}>
+                <input
+                  type="checkbox"
+                  onClick={(e) => handleCheckBox(e, item)}
+                  checked={check24Hrs(item)}
+                />
+                {item.data().item}
+              </li>
+            );
+          })}
+        </ul>
       </div>
 
       <Nav />

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -17,21 +17,21 @@ export default function List() {
   const handleCheckBox = (e, item) => {
     e.preventDefault();
     let now = Timestamp.now().seconds;
-    // console.log("NOW: ", now)
-    // let dayFromNow = now + 86400
-    // console.log("day later: ", dayFromNow);
     const docItem = doc(db, userToken, item.id);
-    console.log('ITEM: ', docItem);
-
     updateDoc(docItem, {
       lastPurchaseDate: now,
     });
   };
 
   const check24Hrs = (item) => {
-    //  have it check the last purchase date for the item
-    // take line 15 => run that difference.. eg; now - items purchase date?
-    console.log('check 24 item last purchase');
+    let now = Timestamp.now().seconds;
+    let itemPurchaseDate = item.data().lastPurchaseDate;
+    let difference = now - itemPurchaseDate;
+    // We are using 86400 which is 24 hours in seconds since `now` is also in seconds
+    if (difference < 86400) {
+      return true;
+    }
+    return false;
   };
 
   useEffect(() => {
@@ -55,9 +55,12 @@ export default function List() {
             return (
               <li key={index}>
                 <input
+                  aria-label="checkbox for purchased item"
+                  id={item.data().id}
                   type="checkbox"
-                  onClick={(e) => handleCheckBox(e, item)}
+                  onChange={(e) => handleCheckBox(e, item)}
                   checked={check24Hrs(item)}
+                  disabled={check24Hrs(item)}
                 />
                 {item.data().item}
               </li>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -23,15 +23,12 @@ export default function List() {
     });
   };
 
-  const check24Hrs = (item) => {
+  const wasPurchasedWithin24Hours = (item) => {
     let now = Timestamp.now().seconds;
     let itemPurchaseDate = item.data().lastPurchaseDate;
     let difference = now - itemPurchaseDate;
-    // We are using 86400 which is 24 hours in seconds since `now` is also in seconds
-    if (difference < 86400) {
-      return true;
-    }
-    return false;
+    const secondsInDay = 86400;
+    return difference < secondsInDay;
   };
 
   useEffect(() => {
@@ -59,8 +56,8 @@ export default function List() {
                   id={item.data().id}
                   type="checkbox"
                   onChange={(e) => handleCheckBox(e, item)}
-                  checked={check24Hrs(item)}
-                  disabled={check24Hrs(item)}
+                  checked={wasPurchasedWithin24Hours(item)}
+                  disabled={wasPurchasedWithin24Hours(item)}
                 />
                 {item.data().item}
               </li>


### PR DESCRIPTION
## Description

Updated the List component to have each list item have a checkbox for the user to indicate if an item has been purchased. If it has been checked, update the `lastPurchaseDate` (the value is in seconds) property for that item in the firestore database.

Added functionality to check if the item was purchased within a 24-hour period. If so, have the checkbox be checked and disabled until the 24 hours period is over.

Added aria-label for input checkbox for accessibility. 

## Related Issue

close #8 

## Acceptance Criteria

- [x] User is able to tap a checkbox or similar UI element to mark an item in the list as purchased
- [x] Item should be shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="1324" alt="Screen Shot 2022-04-26 at 3 36 19 PM" src="https://user-images.githubusercontent.com/54180641/165396566-e917604e-ebef-4259-9c08-964beddb1206.png">

### After

<img width="1328" alt="Screen Shot 2022-04-26 at 3 32 37 PM" src="https://user-images.githubusercontent.com/54180641/165396585-3de7308a-2b85-4c33-b9bc-ba9293af1b15.png">

## Testing Steps / QA Criteria

- From your terminal, check out this branch with `git checkout origin rt-sk-add-purchased-checkbox` and pull that branch with `git pull rt-sk-add-purchased-checkbox`
- Run npm start to launch the app
- Enter token `frame shrank adam`
- Check one item on the list as purchased 
- Navigate to the database in firestore, search for the user with token `frame shrank adam` and change the property `lastPurchasedDate` for that item that you checked to have a value of `TIME - 86410` (for example, 1651008814 - 86410 = 1650922404 so you will change the `lastPurchasedDate` value to 1650922404)  and go back to your browser running the app to see that item has been unchecked.
<img width="1050" alt="Screen Shot 2022-04-26 at 3 45 36 PM" src="https://user-images.githubusercontent.com/54180641/165398141-2a67f713-d553-4d2a-a468-f8debed619b8.png">

- *OR* you can edit line 31 from 86400 (which is 24 hours in seconds) to be a small number of seconds (i.e. 10) and watch the checkbox update on page load/refresh.