### PR TITLE
La ng sort list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,3 +18,15 @@ a {
   font-size: 23px;
   font-weight: bold;
 }
+.soon {
+  background: green;
+}
+.kinda-soon {
+  background: blue;
+}
+.not-soon {
+  background: purple;
+}
+.inactive {
+  background: gray;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -19,14 +19,14 @@ a {
   font-weight: bold;
 }
 .soon {
-  background: green;
+  background-color: green;
 }
 .kinda-soon {
-  background: blue;
+  background-color: blue;
 }
 .not-soon {
-  background: purple;
+  background-color: purple;
 }
 .inactive {
-  background: gray;
+  background-color: gray;
 }

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -56,9 +56,10 @@ export default function List() {
     const lastPurchase = item.data().lastPurchaseDate;
     const itemCreated = item.data().dateItemAdded;
 
-    lastPurchase === null
-      ? Math.round((now - itemCreated) / 86400)
-      : Math.round((now - lastPurchase) / 86400);
+    if (!lastPurchase) {
+      return Math.round((now - itemCreated) / 86400);
+    }
+    return Math.round((now - lastPurchase) / 86400);
   };
 
   const daysUntilNextPurchase = (item) => {
@@ -67,20 +68,13 @@ export default function List() {
 
   const isActive = (item) => {
     return (
-      item.data().totalPurchases > 1 &&
+      !wasPurchasedWithin24Hours(item) &&
+      item.data().totalPurchases > 0 &&
       daysSinceLastPurchase(item) < item.data().estimatedPurchaseInterval * 2
     );
   };
 
   const determinePurchaseCategory = (item) => {
-    console.log('name: ', item.data().item);
-    console.log('Days since last purchase: ', daysSinceLastPurchase(item));
-    console.log(
-      'estimated purchase interval: ',
-      item.data().estimatedPurchaseInterval,
-    );
-    console.log('days until next purchase: ', daysUntilNextPurchase(item));
-
     if (!isActive(item)) {
       return 'inactive';
     }
@@ -106,6 +100,7 @@ export default function List() {
         return 1;
       }
     });
+    return docs;
   };
 
   useEffect(() => {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -168,23 +168,23 @@ export default function List() {
               .map((item, index) => {
                 return (
                   <div>
-                      <li key={index}>
-                    <label
-                      className={determinePurchaseCategory(item)}
-                      aria-label={`next purchase is ${determinePurchaseCategory(
-                        item,
-                      )}`}
-                    >
-                      <input
-                        aria-label="checkbox for purchased item"
-                        id={item.data().id}
-                        type="checkbox"
-                        onChange={(e) => handleCheckBox(e, item)}
-                        checked={wasPurchasedWithin24Hours(item)}
-                        disabled={wasPurchasedWithin24Hours(item)}
-                      />          
-                    </label>
-                    {item.data().item}
+                    <li key={index}>
+                      <label
+                        className={determinePurchaseCategory(item)}
+                        aria-label={`next purchase is ${determinePurchaseCategory(
+                          item,
+                        )}`}
+                      >
+                        <input
+                          aria-label="checkbox for purchased item"
+                          id={item.data().id}
+                          type="checkbox"
+                          onChange={(e) => checkboxHandler(e, item)}
+                          checked={wasPurchasedWithin24Hours(item)}
+                          disabled={wasPurchasedWithin24Hours(item)}
+                        />
+                      </label>
+                      {item.data().item}
                       <button onClick={() => deleteHandler(item)}>
                         delete
                       </button>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -93,7 +93,36 @@ export default function List() {
           />
 
           <button onClick={() => setSearchInputValue(() => '')}>Reset</button>
+          {/*
+PEDAC
+Problem: sort doc items according to how soon they should be purchased. Each item should be marked as either needing to be bought soon, kinda soon, not soon or inactive. Items will appear in the list with different colored checkboxes according to which group they belong to and then alphabetically within the group. 
 
+
+Examples: how to test (maybe include how to edit fields in firestore and what order the list should appear in with those values)
+
+Data Structures: 
+
+     Input: item
+     Output: soon, kindaSoon, notSoon, inactive
+
+Algorithm: 
+DaysUntilNextPurcahse = now - purchase interval(seconds))/ 86400
+         sort first by DaysUntilNextPurcahse
+
+         inactive: if purchaseInterval is out of date
+                      if totalPurchase === 1 || 
+                      if (now - lastPurchaseDate / 86400) * 2 >= estimated purchase interval
+
+          soon: if DaysUntilNextPurcahse < 7
+
+          kindaSoon: if DaysUntilNextPurcahse >= 7 && <= 30
+
+          notSoon: if DaysUntilNextPurcahse > 30
+
+
+Code:
+daysUntilNextPurchase = (Math.round(((Date.now()/1000) - item.data().lastPurchasedate)/86400))         
+*/}
           <ul>
             {docs
               .filter((item) => {


### PR DESCRIPTION
## Description

This PR adds functionality to the list view that orders the shopping list according to how many days are left before items are due for purchase. Items that are due sooner appear closer to the top of the list. The checkboxes for each item are styled according to which of 3 categories they fall into (items that need to be purchased "soon", "kinda soon", "not soon" or "inactive"). 

## Related Issue

closes #12

## Acceptance Criteria

- [x] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [x] Items should be sorted by the estimated number of days until the next purchase
- [x] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/60862882/167766152-a17e8b45-d861-4e6b-8951-2d8a2db075f3.png)

### After
<img width="729" alt="sortList" src="https://user-images.githubusercontent.com/60862882/168427293-12b6ee8f-cdd7-4149-858e-1dedd333d4f0.png">

## Testing Steps / QA Criteria
* From your terminal, pull down this branch with `git fetch` followed by `git switch la-ng-sort-list`
* Run `npm start` to launch the app
* add items to your list until you have at least 6
* mark all items as purchased- all items should become 'inactive' (grey)
* go to firestore and find the list associated with your user token

* **keep in mind that items should be ordered by
                      estimatedPurchcaseInterval - daysSinceLastPurchase**

Testing for "soon", "kinda soon" and "not soon" styling/ordering:
* manually edit one item in the following way:
       * subtract 100,000 from lastPurchaseDate (making it ~1 day since last purchase)
       * change estimatedPurchaseInterval to a number between 1 and 7 (the item should display at the top of the list with green styling)
       
* manually edit another item in the following way:
       * subtract 100,000 from lastPurchaseDate (making it ~1 days since last purchase)
       * change estimatedPurchaseInterval to a number between  8 and 31 (the item should display with blue styling below any green items) 
         
* manually edit another item in the following way:
       * subtract 100,000 from lastPurchaseDate (making it ~1 days since last purchase)
       * change estimatedPurchaseInterval to a number greater than 31 (the item should display with purple styling below any blue items)    

Testing for inactive state:
* manually edit one of the active items from your list by setting totalPurchases to 0. the item should display with grey styling below any purple list items

otherwise, to trigger the inactive state, the days since last purchase must be twice the estimated purchase interval.

example:
* manually edit one of the active items from your list by setting the estimatedPurchaseInterval to any number greater than 0. 
* multiply estimatedPurchaseInterval by 2, then by 100,000.
* subtract that number from lastPurchaseDate
   The item should display with grey styling below any purple list items

© 2022 GitHub, Inc.
Terms
Privacy
Security
Status
